### PR TITLE
ci: bump to Go-1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: [1.15.x, 1.14.x]
+        go-version: [1.16.x, 1.15.x]
         platform: [ubuntu-latest, windows-latest]
         #platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
Signed-off-by: Sebastien Binet <binet@cern.ch>