### PR TITLE
p5: fix outdated example in documentation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,5 +8,6 @@
 
 # Please keep the list sorted.
 
+Lucas Cruz dos Reis <lcr.ergo@gmail.com>
 Pantelis Sampaziotis <psampaz@gmail.com>
 Sebastien Binet <binet@cern.ch>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,5 +15,6 @@
 #
 # Please keep the list sorted.
 
+Lucas Cruz dos Reis <lcr.ergo@gmail.com>
 Pantelis Sampaziotis <psampaz@gmail.com>
 Sebastien Binet <binet@cern.ch>

--- a/p5.go
+++ b/p5.go
@@ -25,7 +25,7 @@
 //
 //	func draw() {
 //	    p5.Fill(color.White)
-//	    p5.Square(10, 10, 50, 50)
+//	    p5.Square(10, 10, 50)
 //	}
 //
 // p5 actually provides two set of APIs:


### PR DESCRIPTION
The main example of the library on godoc shows
an outdated use of the Square function where it has 4 arguments instead of 3.

Fixes #61